### PR TITLE
Exception fixed within showDownloadStatus cancelDownloadButton

### DIFF
--- a/js/view/folioItems/FolioItemView.js
+++ b/js/view/folioItems/FolioItemView.js
@@ -495,11 +495,10 @@ ADOBE.FolioItemView = Backbone.View.extend({
 				this.$downloadStatus.off();
 				this.$downloadStatus.remove();
 				this.$downloadStatus = null;
-				
+
+				this.$cancelDownloadButton.off("click");
 				this.$cancelDownloadButton.remove();
 				this.$cancelDownloadButton = null;
-				
-				this.$cancelDownloadButton.off("click");
 			}
 		}
 	},


### PR DESCRIPTION
From the library template generated by Adobe's online Store Configurator, there's an exception thrown within the showDownloadStatus function.

When removing the download status, off is called after cancelDownloadButton has been set to null.

Disposal of cancelDownloadButton updated.
